### PR TITLE
chore: remove react prop-type rule

### DIFF
--- a/tmt-app/.eslintrc.json
+++ b/tmt-app/.eslintrc.json
@@ -17,6 +17,7 @@
   },
   "plugins": ["react", "react-hooks", "prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "react/prop-types": "off"
   }
 }


### PR DESCRIPTION
This PR turns off react/prop-type enforcement