### PR TITLE
chore: change page title to pick a major

### DIFF
--- a/tmt-app/public/index.html
+++ b/tmt-app/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Pick a Major</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This PR changes the page title to "Pick a Major" instead of "React App"

![image](https://user-images.githubusercontent.com/12107969/223635643-997cd7d3-b62f-4c5a-a3ee-fd651b7f1949.png)
